### PR TITLE
Update stdlib and inifile dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,16 @@ Also, if this module is installed on a node, an `data_entitlement` fact is inclu
 
 This module is documented via `pdk bundle exec puppet strings generate --format markdown`. Please see [REFERENCE.md](REFERENCE.md) for more info.
 
+## Releases
+
+To release a new version of the module, run the Auto release Github
+Action. It will generate new documentation, update the changelogs, and bump the
+version based on the labels on the PRs included in the release. It will open a
+PR, which should be reviewed and merged.
+
+Once the release prep has been merged to the main branch, run the Publish
+module action to tag the release and release it to the Forge.
+
 ## Changelog
 
 [CHANGELOG.md](CHANGELOG.md) is generated prior to each release via `pdk bundle exec rake changelog`. This process relies on labels that are applied to each pull request.

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-data_entitlement",
-  "version": "0.0.1",
+  "version": "0.1.3",
   "author": "puppetlabs",
   "summary": "Used to configure connections with a Puppet Data Entitlement Service, or run a dev stack with docker.",
   "license": "Apache-2.0",
@@ -14,11 +14,11 @@
     },
     {
       "name": "puppetlabs/inifile",
-      "version_requirement": ">= 2.2.1 < 5.0.0"
+      "version_requirement": ">= 2.2.1 < 6.0.0"
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 7.0.0 < 8.0.0"
+      "version_requirement": ">= 7.0.0 < 9.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Update stdlib and inifile dependencies.

Update version for first release using the pdk tooling. Previous
releases built the module release manually, so this version is out of
date.